### PR TITLE
favicon.js added

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -859,6 +859,7 @@
 		<script src="js/jquery.stellar.min.js"></script>
 		<script src="js/maplace-0.1.3.min.js"></script>
 		<script src="js/script.js"></script>
+		<script src="js/favicon.js"></script>
 
 	</body>
 

--- a/web/js/favicon.js
+++ b/web/js/favicon.js
@@ -1,0 +1,22 @@
+
+// Get head element from frame parent document
+var head = parent.document.getElementsByTagName("head")[0];
+
+// URLs for favicons
+var favUrl = "https://wellconnectednow2.herokuapp.com/images/favicons/favicon.ico";
+var appUrl = "https://wellconnectednow2.herokuapp.com/images/favicons/apple-touch-icon.png";
+
+// create new link elements
+var link1 = document.createElement("link");
+var link2 = document.createElement("link");
+
+// Set attributes of each link element
+link1.setAttribute("rel", "icon");
+link1.setAttribute("href", favUrl);
+
+link2.setAttribute("rel", "apple-touch-icon");
+link2.setAttribute("href", appUrl);
+
+// And add them to the head element
+head.appendChild(link1);
+head.appendChild(link2);


### PR DESCRIPTION
This adds a small JavaScript snippet (favicon.js) that should automatically inject favicon link elements into the head element of the frameset parent document generated by GoDaddy
